### PR TITLE
feat: remove node 12 support and add node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-versions: ['12', '14', '16']
+        node-versions: ['14', '16', '18']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "scripts": {
         "test": "jest"
     },
+    "engines": {
+        "node": ">= 14.0.0"
+    },
     "dependencies": {
         "babel-loader": "^8.0.5",
         "babel-preset-react-app": "^10.0.0",


### PR DESCRIPTION
BREAKING CHANGE: The minimum supported node version is now node12