### PR TITLE
feat: add config option to specify inline asset limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ The first function you must call is `initialize` the will start off the
 generation of the config. You can pass an object into the function to
 customize your config.
 
-| Option      | Default  | Description                                                                                      |
-| ----------- | -------- | ------------------------------------------------------------------------------------------------ |
-| src_path    | ./src    | The base path for all of the assets                                                              |
-| dest_path   | ./dist   | The path where you compiled asses will be put                                                    |
-| public_path | /        | The path where you assets are going to be saved. This is used for the urls in the manifest files |
-| production  | NODE_ENV | This will not generally need to be set as it set from the node environment                       |
+| Option                  | Default   | Description                                                                                                                                                     |
+| ----------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| src_path                | ./src     | The base path for all of the assets                                                                                                                             |
+| dest_path               | ./dist    | The path where you compiled asses will be put                                                                                                                   |
+| public_path             | /         | The path where you assets are going to be saved. This is used for the urls in the manifest files                                                                |
+| production              | NODE_ENV  | This will not generally need to be set as it set from the node environment                                                                                      |
+| asset_inline_size_limit | 4 \* 1024 | The file size limit of inline assets. This will determine whether assets will be injected as a Base64-encoded string or a link to an external file will be used |
 
 ### Babel
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const baseOptions = {
         historyApiFallback: true,
         port: 9000,
     },
+    asset_inline_size_limit: 4 * 1024,
 };
 
 baseOptions.entry_point = [`${baseOptions.src_path}/index.tsx`];
@@ -97,6 +98,11 @@ const initialize = _config => {
     loaders.push({
         test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
         type: 'asset',
+        parser: {
+            dataUrlCondition: {
+                maxSize: _config.asset_inline_size_limit,
+            },
+        },
     });
 
     /**


### PR DESCRIPTION
added a new property in the config to define what the max file size of
an inline asset will be before it gets extracted into its own external
resource. The default value is 4KB. By adding this the end user can
define their own limit, if they do not want any inline assets they can
make the max file size limit as 0